### PR TITLE
Updates for modifications in Spring 3.2

### DIFF
--- a/src/test/java/org/springframework/samples/async/chat/ChatControllerTests.java
+++ b/src/test/java/org/springframework/samples/async/chat/ChatControllerTests.java
@@ -19,11 +19,11 @@ import static org.easymock.EasyMock.createStrictMock;
 import static org.easymock.EasyMock.expect;
 import static org.easymock.EasyMock.replay;
 import static org.easymock.EasyMock.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standaloneSetup;
+import static org.springframework.test.web.mock.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.mock.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.mock.servlet.result.MockMvcResultMatchers.request;
+import static org.springframework.test.web.mock.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.mock.servlet.setup.MockMvcBuilders.standaloneSetup;
 
 import java.util.Arrays;
 
@@ -32,7 +32,7 @@ import org.junit.Test;
 import org.springframework.http.MediaType;
 import org.springframework.samples.async.chat.ChatController;
 import org.springframework.samples.async.chat.ChatRepository;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.mock.servlet.MockMvc;
 
 public class ChatControllerTests {
 
@@ -53,7 +53,7 @@ public class ChatControllerTests {
 
 		this.mockMvc.perform(get("/mvc/chat/tennis/John").param("messageIndex", "9"))
 				.andExpect(status().isOk())
-				.andExpect(content().contentType(MediaType.APPLICATION_JSON))
+				.andExpect(content().mimeType(MediaType.APPLICATION_JSON))
 				.andExpect(content().string("[\"a\",\"b\",\"c\"]"))
 				.andExpect(request().asyncNotStarted());
 


### PR DESCRIPTION
A few updates to reflect changes in Spring 3.2
- Use the org.springframework.test.web.mock.\* package names
- Use mimeType instead of contentType
