### PR TITLE
Add SpringSource snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,6 +136,18 @@
 		<repository>
 			<id>SpringSource repository</id>
 			<url>http://repo.springsource.org/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+			<releases>
+				<enabled>true</enabled>
+			</releases>
+		</repository>
+		<repository>
+			<id>SpringSource snapshot repository</id>
+			<url>http://repo.springsource.org/snapshot</url>
+			<snapshots><enabled>true</enabled></snapshots>
+			<releases><enabled>false</enabled></releases>
 		</repository>
 	</repositories>
 	


### PR DESCRIPTION
This allows the spring snapshot builds to be downloaded rather than requiring them to be built locally.
