### PR TITLE
Remove additional chatRequests.remove(deferredResult)

### DIFF
--- a/src/main/java/org/springframework/samples/async/chat/ChatController.java
+++ b/src/main/java/org/springframework/samples/async/chat/ChatController.java
@@ -45,7 +45,6 @@ public class ChatController {
 
 		List<String> messages = this.chatRepository.getMessages(messageIndex);
 		if (!messages.isEmpty()) {
-			this.chatRequests.remove(deferredResult);
 			deferredResult.setResult(messages);
 		}
 


### PR DESCRIPTION
Since the async processing occurs even when the result is immediately
available, onCompletion will remove the deferredResult. This removes
the additional chatRequests.remove(deferredResult)
